### PR TITLE
Overload set_envdata

### DIFF
--- a/src/ccs811.cpp
+++ b/src/ccs811.cpp
@@ -320,6 +320,26 @@ bool CCS811::set_envdata(uint16_t t, uint16_t h) {
   return ok;
 }
 
+uint16_t to_uint16(float v){
+  // Separate the integer part and the decimal part
+  double int_part;
+  double dec_part = modf((double) v, &int_part);
+
+  // Integer part is in put in bit 15-9 and decimal in bit 8-0. Map the decimals to 9 bits with MSB
+  // as 1/2 and LSB as 1/512 (see datasheet)
+  uint16_t high = (uint16_t) int_part << 9;
+  uint16_t low = (uint16_t) (dec_part * 512);
+
+  return high + low;
+}
+
+bool CCS811::set_envdata(float t, float h) {
+  uint16_t t16 = to_uint16(t + 25); // Offset +25 degrees (see datasheet)
+  uint16_t h16 = to_uint16(h);
+
+  return CCS811::set_envdata(t16, h16);
+}
+
 
 // Writes t and h (in ENS210 format) to ENV_DATA. Returns false on I2C problems.
 bool CCS811::set_envdata210(uint16_t t, uint16_t h) {

--- a/src/ccs811.h
+++ b/src/ccs811.h
@@ -75,6 +75,7 @@ class CCS811 {
     int  application_version(void);                                           // Gets version of the CCS811 application (returns -1 on I2C failure)
     int  get_errorid(void);                                                   // Gets the ERROR_ID [same as 'err' part of 'errstat' in 'read'] (returns -1 on I2C failure)
     bool set_envdata(uint16_t t, uint16_t h);                                 // Writes t and h to ENV_DATA (see datasheet for format). Returns false on I2C problems.
+    bool set_envdata(float t, float h);                                       // Convert and write t and h to ENV_DATA. Returns false on I2C problems.
     bool set_envdata210(uint16_t t, uint16_t h);                              // Writes t and h (in ENS210 format) to ENV_DATA. Returns false on I2C problems.
     bool get_baseline(uint16_t *baseline);                                    // Reads (encoded) baseline from BASELINE. Returns false on I2C problems. Get it, just before power down (but only when sensor was on at least 20min) - see CCS811_AN000370
     bool set_baseline(uint16_t baseline);                                     // Writes (encoded) baseline to BASELINE. Returns false on I2C problems. Set it, after power up (and after 20min)


### PR DESCRIPTION
Overload set_envdata with (float temperature, float humidity) for direct celsius and RH input and automatic data type conversion to uint16.

I use a temperature and humidity sensor/library that gives the temperature and humidity as floating points. I made a conversion function to the uint16 data type specified in the datasheet and thought somebody else might like it as well.