### PR TITLE
Readme update(Lolin lite support)

### DIFF
--- a/examples/ccs811flash/README.md
+++ b/examples/ccs811flash/README.md
@@ -186,5 +186,6 @@ Table with successful flashes.
 | 15 | @SFeli            | 2019 Dec 29  | v10      | CJMCU-8128                 | ESP32               | Arduino     |
 | 16 | @ciphercore       | 2020 Jan 10  | v10      | CJMCU-811                  | Arduino Uno         | Arduino     |
 | 17 | @luytendries      | 2020 Feb 10  | v10      | CJMCU-811                  | ESP32               | Arduino     |
+| 18 | @soczkers         | 2020 Apr  1  | v10      | CJMCU-8128                 | ESP32 (lolin lite)  | Arduino     |
 
 (end of doc)


### PR DESCRIPTION
Changes:
`CCS811 ccs811(22);
Wire.begin(23,19);
`
 to use different pins